### PR TITLE
Adding support of the timestamp, fix for querying a subquery with a capital alias.

### DIFF
--- a/lib/make/makeJoinForPipeline.js
+++ b/lib/make/makeJoinForPipeline.js
@@ -124,7 +124,10 @@ function makeJoinPart(join, previousJoin, aliases, pipeline, context) {
                 (a) => a !== toAs && a !== toTable && val.startsWith(`$${a}.`)
             )
         ) {
-            const varName = val.substring(1).replace(/[.-]/g, '_');
+            const varName = lowerCaseFist(
+                val.substring(1).replace(/[.-]/g, '_')
+            );
+
             inputVars[varName] = `$${val.substring(1)}`;
             replacePaths.push({path: path, newVal: `$$${varName}`});
         }
@@ -319,4 +322,13 @@ function tableJoin(
     } else {
         throw new Error(`Join not supported:${join.join}`);
     }
+}
+
+/**
+ *
+ * @param {string} val
+ * @returns {string}
+ */
+function lowerCaseFist(val) {
+    return `${val.charAt(0).toLowerCase()}${val.substring(1)}`;
 }

--- a/lib/make/makeQueryPart.js
+++ b/lib/make/makeQueryPart.js
@@ -301,5 +301,8 @@ function makeQueryPart(
     if (queryPart.type !== 'null' && !$check.assigned(columnNameOrValue)) {
         throw new Error('Unable to make query part for:' + queryPart.type);
     }
+    if (queryPart.type === 'timestamp') {
+        return new Date(columnNameOrValue);
+    }
     return columnNameOrValue;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synatic/noql",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "description": "Convert SQL statements to mongo queries or aggregates",
   "main": "index.js",
   "files": [

--- a/test/bug-fix-tests/bug-fix.json
+++ b/test/bug-fix-tests/bug-fix.json
@@ -539,6 +539,21 @@
           }
         ]
       }
+    },
+    "timestamp": {
+      "case1": {
+        "expectedResults": [
+          {
+            "id": 1,
+            "item": "almonds",
+            "price": 12,
+            "quantity": 2,
+            "customerId": 1,
+            "specialChars": "^^^",
+            "orderDate": "$date-placeholder"
+          }
+        ]
+      }
     }
   }
 }

--- a/test/bug-fix-tests/bug-fix.json
+++ b/test/bug-fix-tests/bug-fix.json
@@ -512,6 +512,33 @@
           ]
         }
       }
+    },
+    "subquery-capitalisation": {
+      "case1": {
+        "expectedResults": [
+          {
+            "id": 1,
+            "item": "almonds"
+          }
+        ],
+        "pipeline": [
+          {
+            "$match": {
+              "orderDate": {
+                "$gt": "2020-01-01 00:00:00"
+              }
+            }
+          },
+          {
+            "$unset": [
+              "_id"
+            ]
+          },
+          {
+            "$limit": 1
+          }
+        ]
+      }
     }
   }
 }

--- a/test/bug-fix-tests/bug-fix.test.js
+++ b/test/bug-fix-tests/bug-fix.test.js
@@ -609,4 +609,22 @@ describe('bug-fixes', function () {
             }
         });
     });
+    describe('subquery capitalisation', () => {
+        it('should not throw an error when the right hand side is capitalised', async () => {
+            const queryString = `
+                SELECT  Order1.id,
+                        Order1.item,
+                        unset(_id)
+                FROM orders Order1
+                INNER JOIN(
+                    SELECT * FROM orders) 'Order2|unwind' on Order2.id = Order1.id
+                LIMIT 1
+            `;
+            await queryResultTester({
+                queryString: queryString,
+                casePath: 'bugfix.subquery-capitalisation.case1',
+                mode,
+            });
+        });
+    });
 });

--- a/test/bug-fix-tests/bug-fix.test.js
+++ b/test/bug-fix-tests/bug-fix.test.js
@@ -627,4 +627,21 @@ describe('bug-fixes', function () {
             });
         });
     });
+    describe('timestamp query', () => {
+        it('should be able to query by timestamp', async () => {
+            const queryString = `
+                SELECT  *,
+                        unset(_id)
+                FROM orders
+                WHERE orderDate > timestamp '2021-01-01 00:00:00'
+                LIMIT 1
+            `;
+            await queryResultTester({
+                queryString: queryString,
+                casePath: 'bugfix.timestamp.case1',
+                mode,
+                ignoreDateValues: true,
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Support for timestamp queries

Example query, now works:
```
SELECT  *,
        unset(_id)
FROM orders
WHERE orderDate > timestamp '2021-01-01 00:00:00'
LIMIT 1
```
## Ability to query SubQueries that start with a capital letter

Previously the following query would not have worked unless `Order2` started with `order2`:

```
SELECT  Order1.id,
        Order1.item,
        unset(_id)
FROM orders Order1
INNER JOIN(
    SELECT * FROM orders) 'Order2|unwind' on Order2.id = Order1.id
LIMIT 1
```
